### PR TITLE
Add CPUInfo class that provides information about ISA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,3 +11,7 @@ add_subdirectory(src)
 if (BUILD_TESTING)
     add_subdirectory(tests)
 endif()
+
+if (BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(cpuinfo)

--- a/examples/cpuinfo/CMakeLists.txt
+++ b/examples/cpuinfo/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(cpuinfo cpuinfo.cpp)
+target_link_libraries(cpuinfo biscuit)
+set_property(TARGET cpuinfo PROPERTY CXX_STANDARD 20)

--- a/examples/cpuinfo/cpuinfo.cpp
+++ b/examples/cpuinfo/cpuinfo.cpp
@@ -1,0 +1,31 @@
+// Copyright (c), 2022, KNS Group LLC (YADRO)
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <biscuit/assembler.hpp>
+#include <biscuit/cpuinfo.hpp>
+
+#include <iostream>
+
+using namespace biscuit;
+
+int main()
+{
+    CPUInfo cpu;
+
+    std::cout << "Has I:" <<  cpu.Has(RISCVExtension::I) << std::endl;
+    std::cout << "Has M:" <<  cpu.Has(RISCVExtension::M) << std::endl;
+    std::cout << "Has A:" <<  cpu.Has(RISCVExtension::A) << std::endl;
+    std::cout << "Has F:" <<  cpu.Has(RISCVExtension::F) << std::endl;
+    std::cout << "Has D:" <<  cpu.Has(RISCVExtension::D) << std::endl;
+    std::cout << "Has C:" <<  cpu.Has(RISCVExtension::C) << std::endl;
+    std::cout << "Has V:" <<  cpu.Has(RISCVExtension::V) << std::endl;
+
+    if (cpu.Has(RISCVExtension::V)) {
+        std::cout << "VLENB:" <<  cpu.GetVlenb() << std::endl;
+    }
+
+    return 0;
+}

--- a/include/biscuit/cpuinfo.hpp
+++ b/include/biscuit/cpuinfo.hpp
@@ -1,0 +1,101 @@
+// Copyright (c), 2022, KNS Group LLC (YADRO)
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#pragma once
+
+#include <biscuit/assembler.hpp>
+#include <biscuit/registers.hpp>
+#include <cstddef>
+#include <cstdint>
+
+#if defined(__linux__) && defined(__riscv)
+#include <sys/auxv.h>
+#include <sys/prctl.h>
+#include <asm/hwcap.h>
+#endif
+
+namespace biscuit {
+
+#ifndef COMPAT_HWCAP_ISA_I
+#define COMPAT_HWCAP_ISA_I  (1U << ('I' - 'A'))
+#endif
+
+#ifndef COMPAT_HWCAP_ISA_M
+#define COMPAT_HWCAP_ISA_M  (1U << ('M' - 'A'))
+#endif
+
+#ifndef COMPAT_HWCAP_ISA_A
+#define COMPAT_HWCAP_ISA_A  (1U << ('A' - 'A'))
+#endif
+
+#ifndef COMPAT_HWCAP_ISA_F
+#define COMPAT_HWCAP_ISA_F  (1U << ('F' - 'A'))
+#endif
+
+#ifndef COMPAT_HWCAP_ISA_D
+#define COMPAT_HWCAP_ISA_D  (1U << ('D' - 'A'))
+#endif
+
+#ifndef COMPAT_HWCAP_ISA_C
+#define COMPAT_HWCAP_ISA_C  (1U << ('C' - 'A'))
+#endif
+
+#ifndef COMPAT_HWCAP_ISA_V
+#define COMPAT_HWCAP_ISA_V  (1U << ('V' - 'A'))
+#endif
+
+enum class RISCVExtension : uint64_t {
+    I = COMPAT_HWCAP_ISA_I,
+    M = COMPAT_HWCAP_ISA_M,
+    A = COMPAT_HWCAP_ISA_A,
+    F = COMPAT_HWCAP_ISA_F,
+    D = COMPAT_HWCAP_ISA_D,
+    C = COMPAT_HWCAP_ISA_C,
+    V = COMPAT_HWCAP_ISA_V
+};
+
+template <CSR csr>
+struct CSRReader : public biscuit::Assembler {
+    // Buffer capacity exactly for 2 instructions.
+    static constexpr size_t capacity = 8;
+
+    CSRReader() : biscuit::Assembler{CSRReader::capacity} {
+        CSRR(a0, csr);
+        RET();
+    }
+
+    // Copy constructor and assignment.
+    CSRReader(const CSRReader&) = delete;
+    CSRReader& operator=(const CSRReader&) = delete;
+
+    // Move constructor and assignment.
+    CSRReader(CSRReader&&) = default;
+    CSRReader& operator=(CSRReader&&) = default;
+
+    template <typename CSRReaderFunc>
+    CSRReaderFunc GetCode() {
+        this->GetCodeBuffer().SetExecutable();
+        return reinterpret_cast<CSRReaderFunc>(this->GetBufferPointer(0));
+    }
+};
+
+/**
+ * Class that detects information about a RISC-V CPU.
+ */
+class CPUInfo {
+public:
+    /**
+     * Checks if a particular RISC-V extension is available.
+     *
+     * @param extension The extension to check.
+     */
+    bool Has(RISCVExtension extension) const;
+
+    /// Returns the vector register length in bytes.
+    uint32_t GetVlenb() const;
+};
+
+} // namespace biscuit

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(biscuit
     assembler_crypto.cpp
     assembler_vector.cpp
     code_buffer.cpp
+    cpuinfo.cpp
 
     # Headers
     "${PROJECT_SOURCE_DIR}/include/biscuit/assembler.hpp"
@@ -16,6 +17,7 @@ add_library(biscuit
     "${PROJECT_SOURCE_DIR}/include/biscuit/label.hpp"
     "${PROJECT_SOURCE_DIR}/include/biscuit/registers.hpp"
     "${PROJECT_SOURCE_DIR}/include/biscuit/vector.hpp"
+    "${PROJECT_SOURCE_DIR}/include/biscuit/cpuinfo.hpp"
 )
 add_library(biscuit::biscuit ALIAS biscuit)
 

--- a/src/cpuinfo.cpp
+++ b/src/cpuinfo.cpp
@@ -1,0 +1,39 @@
+// Copyright (c), 2022, KNS Group LLC (YADRO)
+//
+// Use of this source code is governed by an MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+
+#include <biscuit/cpuinfo.hpp>
+
+namespace biscuit {
+
+bool CPUInfo::Has(RISCVExtension extension) const {
+#if defined(__linux__) && defined(__riscv)
+    const static uint64_t features = getauxval(AT_HWCAP) & (
+                            COMPAT_HWCAP_ISA_I |
+                            COMPAT_HWCAP_ISA_M |
+                            COMPAT_HWCAP_ISA_A |
+                            COMPAT_HWCAP_ISA_F |
+                            COMPAT_HWCAP_ISA_D |
+                            COMPAT_HWCAP_ISA_C |
+                            COMPAT_HWCAP_ISA_V
+    );
+#else
+    const static uint64_t features = 0;
+#endif
+
+    return (features & static_cast<uint64_t>(extension)) != 0;
+}
+
+uint32_t CPUInfo::GetVlenb() const {
+    if(Has(RISCVExtension::V)) {
+        static CSRReader<CSR::VLenb> csrReader;
+        const static auto getVLEN = csrReader.GetCode<uint32_t (*)()>();
+        return getVLEN();
+    }
+
+    return 0;
+}
+
+} // namespace biscuit


### PR DESCRIPTION
This PR adds CPUInfo class that allows getting information about extensions available on a particular RISC-V CPU.

Such feature is, for example, useful for runtime code generation in [OneDNN](https://github.com/oneapi-src/oneDNN). OneDNN uses JIT generators to produce optimal code for some functions based on input parameters and the instruction set supported by the system. See [oneDNN/src/cpu/platform.cpp](https://github.com/oneapi-src/oneDNN/blob/master/src/cpu/platform.cpp) and [oneDNN/src/cpu/x64/jit_uni_eltwise.cpp](https://github.com/oneapi-src/oneDNN/blob/master/src/cpu/x64/jit_uni_eltwise.cpp) for details.

Xbyak implements similar functionality for x64 CPUs in [xbyak/xbyak_util.h](https://github.com/herumi/xbyak/blob/master/xbyak/xbyak_util.h).

There is also a simple example that demonstrates usage of the CPUInfo class.
To compile it, configure CMake build with `-D BUILD_EXAMPLES=ON` option.
Sample output from the example:
```
Has I:1
Has M:1
Has A:1
Has F:1
Has D:1
Has C:1
Has V:1
VLENB:128
```

We are looking forward to hear your opinion on this.
Thanks