### PR TITLE
assembler: Add Zabha support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Includes both 32-bit and 64-bit instructions in the following:
 | S         | 1.12    |
 | V         | 1.0     |
 | Sstc      | 0.5.4   |
+| Zabha     | 1.0     |
 | Zacas     | 1.0     |
 | Zawrs     | 1.01    |
 | Zcb       | 1.0.4   |

--- a/include/biscuit/assembler.hpp
+++ b/include/biscuit/assembler.hpp
@@ -287,6 +287,29 @@ public:
     void AMOCAS_Q(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
     void AMOCAS_W(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
 
+    // Zabha Extension Instructions
+    void AMOADD_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOAND_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOMAX_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOMAXU_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOMIN_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOMINU_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOOR_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOSWAP_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOXOR_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOCAS_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+
+    void AMOADD_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOAND_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOMAX_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOMAXU_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOMIN_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOMINU_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOOR_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOSWAP_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOXOR_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+    void AMOCAS_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept;
+
     // Zicond Extension Instructions
     void CZERO_EQZ(GPR rd, GPR value, GPR condition) noexcept;
     void CZERO_NEZ(GPR rd, GPR value, GPR condition) noexcept;

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -609,6 +609,70 @@ void Assembler::AMOCAS_W(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
     EmitAtomic(m_buffer, 0b00101, ordering, rs2, rs1, 0b010, rd, 0b0101111);
 }
 
+// Zabha Extension Instructions
+
+void Assembler::AMOADD_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b00000, ordering, rs2, rs1, 0b000, rd, 0b0101111);
+}
+void Assembler::AMOAND_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b01100, ordering, rs2, rs1, 0b000, rd, 0b0101111);
+}
+void Assembler::AMOMAX_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b10100, ordering, rs2, rs1, 0b000, rd, 0b0101111);
+}
+void Assembler::AMOMAXU_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b11100, ordering, rs2, rs1, 0b000, rd, 0b0101111);
+}
+void Assembler::AMOMIN_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b10000, ordering, rs2, rs1, 0b000, rd, 0b0101111);
+}
+void Assembler::AMOMINU_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b11000, ordering, rs2, rs1, 0b000, rd, 0b0101111);
+}
+void Assembler::AMOOR_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b01000, ordering, rs2, rs1, 0b000, rd, 0b0101111);
+}
+void Assembler::AMOSWAP_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b00001, ordering, rs2, rs1, 0b000, rd, 0b0101111);
+}
+void Assembler::AMOXOR_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b00100, ordering, rs2, rs1, 0b000, rd, 0b0101111);
+}
+void Assembler::AMOCAS_B(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b00101, ordering, rs2, rs1, 0b000, rd, 0b0101111);
+}
+
+void Assembler::AMOADD_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b00000, ordering, rs2, rs1, 0b001, rd, 0b0101111);
+}
+void Assembler::AMOAND_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b01100, ordering, rs2, rs1, 0b001, rd, 0b0101111);
+}
+void Assembler::AMOMAX_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b10100, ordering, rs2, rs1, 0b001, rd, 0b0101111);
+}
+void Assembler::AMOMAXU_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b11100, ordering, rs2, rs1, 0b001, rd, 0b0101111);
+}
+void Assembler::AMOMIN_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b10000, ordering, rs2, rs1, 0b001, rd, 0b0101111);
+}
+void Assembler::AMOMINU_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b11000, ordering, rs2, rs1, 0b001, rd, 0b0101111);
+}
+void Assembler::AMOOR_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b01000, ordering, rs2, rs1, 0b001, rd, 0b0101111);
+}
+void Assembler::AMOSWAP_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b00001, ordering, rs2, rs1, 0b001, rd, 0b0101111);
+}
+void Assembler::AMOXOR_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b00100, ordering, rs2, rs1, 0b001, rd, 0b0101111);
+}
+void Assembler::AMOCAS_H(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
+    EmitAtomic(m_buffer, 0b00101, ordering, rs2, rs1, 0b001, rd, 0b0101111);
+}
+
 // Zicond Extension Instructions
 
 void Assembler::CZERO_EQZ(GPR rd, GPR value, GPR condition) noexcept {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(${PROJECT_NAME}
     src/assembler_rvq_tests.cpp
     src/assembler_rvv_tests.cpp
     src/assembler_vector_crypto_tests.cpp
+    src/assembler_zabha_tests.cpp
     src/assembler_zacas_tests.cpp
     src/assembler_zawrs_tests.cpp
     src/assembler_zc_tests.cpp

--- a/tests/src/assembler_zabha_tests.cpp
+++ b/tests/src/assembler_zabha_tests.cpp
@@ -1,0 +1,467 @@
+#include <catch/catch.hpp>
+
+#include <biscuit/assembler.hpp>
+
+#include "assembler_test_utils.hpp"
+
+using namespace biscuit;
+
+TEST_CASE("AMOADD.H", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler64(value);
+
+    as.AMOADD_H(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x00779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOADD_H(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x04779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOADD_H(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x02779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOADD_H(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x06779FAF);
+}
+
+TEST_CASE("AMOADD.B", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler32(value);
+
+    as.AMOADD_B(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x00778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOADD_B(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x04778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOADD_B(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x02778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOADD_B(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x06778FAF);
+}
+
+TEST_CASE("AMOAND.H", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler64(value);
+
+    as.AMOAND_H(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x60779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOAND_H(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x64779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOAND_H(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x62779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOAND_H(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x66779FAF);
+}
+
+TEST_CASE("AMOAND.B", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler32(value);
+
+    as.AMOAND_B(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x60778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOAND_B(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x64778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOAND_B(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x62778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOAND_B(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x66778FAF);
+}
+
+TEST_CASE("AMOMAX.H", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler64(value);
+
+    as.AMOMAX_H(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0xA0779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMAX_H(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0xA4779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMAX_H(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0xA2779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMAX_H(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0xA6779FAF);
+}
+
+TEST_CASE("AMOMAX.B", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler32(value);
+
+    as.AMOMAX_B(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0xA0778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMAX_B(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0xA4778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMAX_B(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0xA2778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMAX_B(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0xA6778FAF);
+}
+
+TEST_CASE("AMOMAXU.H", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler64(value);
+
+    as.AMOMAXU_H(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0xE0779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMAXU_H(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0xE4779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMAXU_H(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0xE2779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMAXU_H(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0xE6779FAF);
+}
+
+TEST_CASE("AMOMAXU.B", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler32(value);
+
+    as.AMOMAXU_B(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0xE0778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMAXU_B(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0xE4778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMAXU_B(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0xE2778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMAXU_B(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0xE6778FAF);
+}
+
+TEST_CASE("AMOMIN.H", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler64(value);
+
+    as.AMOMIN_H(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x80779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMIN_H(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x84779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMIN_H(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x82779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMIN_H(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x86779FAF);
+}
+
+TEST_CASE("AMOMIN.B", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler32(value);
+
+    as.AMOMIN_B(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x80778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMIN_B(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x84778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMIN_B(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x82778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMIN_B(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x86778FAF);
+}
+
+TEST_CASE("AMOMINU.H", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler64(value);
+
+    as.AMOMINU_H(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0xC0779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMINU_H(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0xC4779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMINU_H(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0xC2779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMINU_H(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0xC6779FAF);
+}
+
+TEST_CASE("AMOMINU.B", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler32(value);
+
+    as.AMOMINU_B(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0xC0778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMINU_B(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0xC4778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMINU_B(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0xC2778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOMINU_B(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0xC6778FAF);
+}
+
+TEST_CASE("AMOOR.H", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler64(value);
+
+    as.AMOOR_H(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x40779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOOR_H(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x44779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOOR_H(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x42779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOOR_H(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x46779FAF);
+}
+
+TEST_CASE("AMOOR.B", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler32(value);
+
+    as.AMOOR_B(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x40778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOOR_B(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x44778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOOR_B(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x42778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOOR_B(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x46778FAF);
+}
+
+TEST_CASE("AMOSWAP.H", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler64(value);
+
+    as.AMOSWAP_H(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x08779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOSWAP_H(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x0C779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOSWAP_H(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x0A779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOSWAP_H(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x0E779FAF);
+}
+
+TEST_CASE("AMOSWAP.B", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler32(value);
+
+    as.AMOSWAP_B(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x08778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOSWAP_B(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x0C778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOSWAP_B(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x0A778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOSWAP_B(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x0E778FAF);
+}
+
+TEST_CASE("AMOXOR.H", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler64(value);
+
+    as.AMOXOR_H(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x20779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOXOR_H(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x24779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOXOR_H(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x22779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOXOR_H(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x26779FAF);
+}
+
+TEST_CASE("AMOXOR.B", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler32(value);
+
+    as.AMOXOR_B(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x20778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOXOR_B(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x24778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOXOR_B(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x22778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOXOR_B(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x26778FAF);
+}
+
+TEST_CASE("AMOCAS.H", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler64(value);
+
+    as.AMOCAS_H(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x28779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOCAS_H(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x2C779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOCAS_H(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x2A779FAF);
+
+    as.RewindBuffer();
+
+    as.AMOCAS_H(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x2E779FAF);
+}
+
+TEST_CASE("AMOCAS.B", "[Zabha]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler64(value);
+
+    as.AMOCAS_B(Ordering::None, x31, x7, x15);
+    REQUIRE(value == 0x28778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOCAS_B(Ordering::AQ, x31, x7, x15);
+    REQUIRE(value == 0x2C778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOCAS_B(Ordering::RL, x31, x7, x15);
+    REQUIRE(value == 0x2A778FAF);
+
+    as.RewindBuffer();
+
+    as.AMOCAS_B(Ordering::AQRL, x31, x7, x15);
+    REQUIRE(value == 0x2E778FAF);
+}


### PR DESCRIPTION
Added support for the Zabha byte/halfword atomics extension.
Simple addition, the extension simply allows for 0/1 in the funct3 field of atomic operations to represent byte/halfword types.
