### PR TITLE
assembler: Add XTheadCondMov support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,50 +14,51 @@ to how [Xbyak](https://github.com/herumi/xbyak) allows for runtime code generati
 
 Includes both 32-bit and 64-bit instructions in the following:
 
-| Feature   | Version |
-|:----------|:-------:|
-| A         | 2.1     |
-| B         | 1.0     |
-| C         | 2.0     |
-| D         | 2.2     |
-| F         | 2.2     |
-| H         | 1.0     |
-| K         | 1.0.1   |
-| M         | 2.0     |
-| N         | 1.1     |
-| Q         | 2.2     |
-| RV32I     | 2.1     |
-| RV64I     | 2.1     |
-| S         | 1.12    |
-| V         | 1.0     |
-| Ssctr     | 1.0 rc6 |
-| Sstc      | 0.5.4   |
-| Zabha     | 1.0     |
-| Zacas     | 1.0     |
-| Zawrs     | 1.01    |
-| Zcb       | 1.0.4   |
-| Zclsd     | 0.10    |
-| Zcmp      | 1.0.4   |
-| Zcmt      | 1.0.4   |
-| Zfa       | 1.0     |
-| Zfbfmin   | 1.0     |
-| Zfh       | 1.0     |
-| Zfhmin    | 1.0     |
-| Zicbom    | 1.0     |
-| Zicbop    | 1.0     |
-| Zicboz    | 1.0     |
-| Zicfilp   | 1.0     |
-| Zicfiss   | 1.0     |
-| Zicond    | 1.0.1   |
-| Zicsr     | 2.0     |
-| Zifencei  | 2.0     |
-| Zihintntl | 1.0     |
-| Zilsd     | 0.10    |
-| Zvbb      | 1.0     |
-| Zvbc      | 1.0     |
-| Zvfbfmin  | 1.0     |
-| Zvfbfwma  | 1.0     |
-| Zvkn      | 1.0     |
+| Feature       | Version |
+|:--------------|:-------:|
+| A             | 2.1     |
+| B             | 1.0     |
+| C             | 2.0     |
+| D             | 2.2     |
+| F             | 2.2     |
+| H             | 1.0     |
+| K             | 1.0.1   |
+| M             | 2.0     |
+| N             | 1.1     |
+| Q             | 2.2     |
+| RV32I         | 2.1     |
+| RV64I         | 2.1     |
+| S             | 1.12    |
+| V             | 1.0     |
+| Ssctr         | 1.0 rc6 |
+| Sstc          | 0.5.4   |
+| XTheadCondMov | 1.0     |
+| Zabha         | 1.0     |
+| Zacas         | 1.0     |
+| Zawrs         | 1.01    |
+| Zcb           | 1.0.4   |
+| Zclsd         | 0.10    |
+| Zcmp          | 1.0.4   |
+| Zcmt          | 1.0.4   |
+| Zfa           | 1.0     |
+| Zfbfmin       | 1.0     |
+| Zfh           | 1.0     |
+| Zfhmin        | 1.0     |
+| Zicbom        | 1.0     |
+| Zicbop        | 1.0     |
+| Zicboz        | 1.0     |
+| Zicfilp       | 1.0     |
+| Zicfiss       | 1.0     |
+| Zicond        | 1.0.1   |
+| Zicsr         | 2.0     |
+| Zifencei      | 2.0     |
+| Zihintntl     | 1.0     |
+| Zilsd         | 0.10    |
+| Zvbb          | 1.0     |
+| Zvbc          | 1.0     |
+| Zvfbfmin      | 1.0     |
+| Zvfbfwma      | 1.0     |
+| Zvkn          | 1.0     |
 
 Note that usually only extensions considered ratified will be implemented
 as non-ratified documents are considerably more likely to have

--- a/include/biscuit/assembler.hpp
+++ b/include/biscuit/assembler.hpp
@@ -314,6 +314,11 @@ public:
     void CZERO_EQZ(GPR rd, GPR value, GPR condition) noexcept;
     void CZERO_NEZ(GPR rd, GPR value, GPR condition) noexcept;
 
+
+    // XTheadCondMov Extension Instructions
+    void TH_MVEQZ(GPR rd, GPR value, GPR condition) noexcept;
+    void TH_MVNEZ(GPR rd, GPR value, GPR condition) noexcept;
+
     // Zicsr Extension Instructions
 
     void CSRRC(GPR rd, CSR csr, GPR rs) noexcept;

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -682,6 +682,16 @@ void Assembler::CZERO_NEZ(GPR rd, GPR value, GPR condition) noexcept {
     EmitRType(m_buffer, 0b0000111, condition, value, 0b111, rd, 0b0110011);
 }
 
+// XTheadCondMov Extension Instructions
+
+void Assembler::TH_MVEQZ(GPR rd, GPR value, GPR condition) noexcept {
+    EmitRType(m_buffer, 0b0100000, condition, value, 0b001, rd, 0b0001011);
+}
+
+void Assembler::TH_MVNEZ(GPR rd, GPR value, GPR condition) noexcept {
+    EmitRType(m_buffer, 0b0100001, condition, value, 0b001, rd, 0b0001011);
+}
+
 // Zicsr Extension Instructions
 
 void Assembler::CSRRC(GPR rd, CSR csr, GPR rs) noexcept {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(${PROJECT_NAME}
     src/assembler_rvq_tests.cpp
     src/assembler_rvv_tests.cpp
     src/assembler_vector_crypto_tests.cpp
+    src/assembler_xtheadcondmov_tests.cpp
     src/assembler_zabha_tests.cpp
     src/assembler_zacas_tests.cpp
     src/assembler_zawrs_tests.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ add_executable(${PROJECT_NAME}
     src/assembler_rvq_tests.cpp
     src/assembler_rvv_tests.cpp
     src/assembler_vector_crypto_tests.cpp
-    src/assembler_xtheadcondmov_tests.cpp
+    src/assembler_xthead_tests.cpp
     src/assembler_zabha_tests.cpp
     src/assembler_zacas_tests.cpp
     src/assembler_zawrs_tests.cpp

--- a/tests/src/assembler_xthead_tests.cpp
+++ b/tests/src/assembler_xthead_tests.cpp
@@ -6,7 +6,7 @@
 
 using namespace biscuit;
 
-TEST_CASE("TH.MVEQZ", "[XTheadCondMov]") {
+TEST_CASE("TH.MVEQZ", "[XThead]") {
     uint32_t value = 0;
     auto as = MakeAssembler64(value);
 
@@ -19,7 +19,7 @@ TEST_CASE("TH.MVEQZ", "[XTheadCondMov]") {
     REQUIRE(value == 0x4031108B);
 }
 
-TEST_CASE("TH.MVNEZ", "[XTheadCondMov]") {
+TEST_CASE("TH.MVNEZ", "[XThead]") {
     uint32_t value = 0;
     auto as = MakeAssembler64(value);
 

--- a/tests/src/assembler_xtheadcondmov_tests.cpp
+++ b/tests/src/assembler_xtheadcondmov_tests.cpp
@@ -1,0 +1,33 @@
+#include <catch/catch.hpp>
+
+#include <biscuit/assembler.hpp>
+
+#include "assembler_test_utils.hpp"
+
+using namespace biscuit;
+
+TEST_CASE("TH.MVEQZ", "[XTheadCondMov]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler64(value);
+
+    as.TH_MVEQZ(x31, x30, x29);
+    REQUIRE(value == 0x41DF1F8B);
+
+    as.RewindBuffer();
+
+    as.TH_MVEQZ(x1, x2, x3);
+    REQUIRE(value == 0x4031108B);
+}
+
+TEST_CASE("TH.MVNEZ", "[XTheadCondMov]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler64(value);
+
+    as.TH_MVNEZ(x31, x30, x29);
+    REQUIRE(value == 0x43DF1F8B);
+
+    as.RewindBuffer();
+
+    as.TH_MVNEZ(x1, x2, x3);
+    REQUIRE(value == 0x4231108B);
+}


### PR DESCRIPTION
Useful extension for implementing conditional moves in a manner more similar to x86/ARM.
The standard Zicond way to do conditional movs is czero.nez + czero.eqz + or/add, while XTheadCondMov can do it in 1 instruction.

For example:
```
th.mveqz a0,a2,a1
```
versus
```
czero.nez a2,a2,a1
czero.eqz a0,a0,a1
add a0,a0,a2
```

GCC picks it over Zicond when both are available: https://godbolt.org/z/bfG7reh8W

Documentation is in here: https://github.com/XUANTIE-RV/thead-extension-spec/releases/tag/2.3.0