### PR TITLE
Allow cursor to be moved forwards

### DIFF
--- a/include/biscuit/assembler.hpp
+++ b/include/biscuit/assembler.hpp
@@ -112,6 +112,18 @@ public:
         m_buffer.RewindCursor(offset);
     }
 
+    /**
+     * Allows advancing of the code buffer cursor.
+     * 
+     * @param offset The offset to advance the cursor by.
+     *
+     * @note The offset may not be smaller than the current cursor offset 
+     *       and may not be larger than the current buffer capacity.
+     */
+    void AdvanceBuffer(ptrdiff_t offset) {
+        m_buffer.AdvanceCursor(offset);
+    }
+
     /// Retrieves the cursor pointer for the underlying code buffer.
     [[nodiscard]] uint8_t* GetCursorPointer() noexcept {
         return m_buffer.GetCursorPointer();

--- a/include/biscuit/code_buffer.hpp
+++ b/include/biscuit/code_buffer.hpp
@@ -88,14 +88,16 @@ public:
 
     /// Retrieves the pointer to an arbitrary location within the buffer.
     [[nodiscard]] uint8_t* GetOffsetPointer(ptrdiff_t offset) noexcept {
-        BISCUIT_ASSERT(offset >= 0 && offset <= GetCursorOffset());
-        return m_buffer + offset;
+        auto pointer = m_buffer + offset;
+        BISCUIT_ASSERT(pointer >= m_buffer && pointer < m_buffer + m_capacity);
+        return pointer;
     }
 
     /// Retrieves the pointer to an arbitrary location within the buffer.
     [[nodiscard]] const uint8_t* GetOffsetPointer(ptrdiff_t offset) const noexcept {
-        BISCUIT_ASSERT(offset >= 0 && offset <= GetCursorOffset());
-        return m_buffer + offset;
+        auto pointer = m_buffer + offset;
+        BISCUIT_ASSERT(pointer >= m_buffer && pointer < m_buffer + m_capacity);
+        return pointer;
     }
 
     /**
@@ -113,6 +115,20 @@ public:
         auto* rewound = m_buffer + offset;
         BISCUIT_ASSERT(m_buffer <= rewound && rewound <= m_cursor);
         m_cursor = rewound;
+    }
+
+    /**
+     * Allows advancing of the code buffer cursor.
+     * 
+     * @param offset The offset to advance the cursor by.
+     *
+     * @note The offset may not be smaller than the current cursor offset 
+     *       and may not be larger than the current buffer capacity.
+     */
+    void AdvanceCursor(ptrdiff_t offset) noexcept {
+        auto* forward = m_buffer + offset;
+        BISCUIT_ASSERT(m_cursor <= forward && forward < m_buffer + m_capacity);
+        m_cursor = forward;
     }
 
     /**


### PR DESCRIPTION
As mentioned in #13, allows for backpatching instructions then moving back to the previous position.

Example usage:
```cpp
ptrdiff_t cursor = as.GetCodeBuffer().GetCursorOffset();
as.RewindBuffer(jump.location);
Emitter::EmitJump(*this, &block_map[jump.target]);
as.AdvanceBuffer(cursor);
```

Asserts changed in `GetOffsetPointer` to allow for emitting branches to Labels that point forwards in the buffer.

Feel free to suggest changes if this implementation is not optimal.