### PR TITLE
assembler: Add PC-relative literal loads

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_subdirectory(cpuinfo)
+add_subdirectory(literal)

--- a/examples/literal/CMakeLists.txt
+++ b/examples/literal/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(literal literal.cpp)
+target_link_libraries(literal biscuit)
+set_property(TARGET literal PROPERTY CXX_STANDARD 20)

--- a/examples/literal/literal.cpp
+++ b/examples/literal/literal.cpp
@@ -1,0 +1,73 @@
+#include <biscuit/assert.hpp>
+#include <biscuit/assembler.hpp>
+
+#include <iostream>
+
+using namespace biscuit;
+
+constexpr const static uint64_t literal1_value = 0x1234567890ABCDEF;
+constexpr const static uint64_t literal2_value = 0x1122334455667788;
+constexpr const static uint64_t literal3_value = 0xFEDCBA0987654321;
+constexpr const static uint64_t literal4_value = 0xAABBCCDDEEFF0011;
+
+void print_literals(uint64_t literal1, uint64_t literal2, uint64_t literal3, uint64_t literal4) {
+    std::cout << "Literal 1: " << std::hex << literal1 << std::endl;
+    std::cout << "Literal 2: " << std::hex << literal2 << std::endl;
+    std::cout << "Literal 3: " << std::hex << literal3 << std::endl;
+    std::cout << "Literal 4: " << std::hex << literal4 << std::endl;
+
+    BISCUIT_ASSERT(literal1 == literal1_value);
+    BISCUIT_ASSERT(literal2 == literal2_value);
+    BISCUIT_ASSERT(literal3 == literal3_value);
+    BISCUIT_ASSERT(literal4 == literal4_value);
+}
+
+int main() {
+    Assembler as(0x5000);
+
+    Literal64 literal1(literal1_value);
+    Literal64 literal2(literal2_value);
+    Literal64 literal3(literal3_value);
+    Literal64 literal4(literal4_value);
+
+    // Literal placed before the code, more than 0x1000 bytes away
+    as.Place(&literal1);
+
+    as.AdvanceBuffer(as.GetCodeBuffer().GetCursorOffset() + 0x1000);
+
+    // Literal placed before the code, less than 0x1000 bytes away
+    as.Place(&literal2);
+
+    void (*code)() = reinterpret_cast<void(*)()>(as.GetCursorPointer());
+    as.ADDI(sp, sp, -8);
+    as.SD(ra, 0, sp);
+
+    as.LD(a0, &literal1);
+
+    as.LD(a1, &literal2);
+
+    as.LD(a2, &literal3);
+
+    as.LD(a3, &literal4);
+
+    as.LI(t0, (uint64_t)print_literals);
+    as.JALR(t0);
+
+    as.LD(ra, 0, sp);
+    as.ADDI(sp, sp, 8);
+    as.RET();
+
+    // Literal placed after the code, less than 0x1000 bytes away
+    as.Place(&literal3);
+
+    as.AdvanceBuffer(as.GetCodeBuffer().GetCursorOffset() + 0x1000);
+
+    // Literal placed after the code, more than 0x1000 bytes away
+    as.Place(&literal4);
+
+    as.GetCodeBuffer().SetExecutable();
+
+    code();
+
+    return 0;
+}

--- a/examples/literal/literal.cpp
+++ b/examples/literal/literal.cpp
@@ -5,10 +5,10 @@
 
 using namespace biscuit;
 
-constexpr const static uint64_t literal1_value = 0x1234567890ABCDEF;
-constexpr const static uint64_t literal2_value = 0x1122334455667788;
-constexpr const static uint64_t literal3_value = 0xFEDCBA0987654321;
-constexpr const static uint64_t literal4_value = 0xAABBCCDDEEFF0011;
+constexpr uint64_t literal1_value = 0x1234567890ABCDEF;
+constexpr uint64_t literal2_value = 0x1122334455667788;
+constexpr uint64_t literal3_value = 0xFEDCBA0987654321;
+constexpr uint64_t literal4_value = 0xAABBCCDDEEFF0011;
 
 void print_literals(uint64_t literal1, uint64_t literal2, uint64_t literal3, uint64_t literal4) {
     std::cout << "Literal 1: " << std::hex << literal1 << std::endl;

--- a/examples/literal/literal.cpp
+++ b/examples/literal/literal.cpp
@@ -5,30 +5,43 @@
 
 using namespace biscuit;
 
+struct BigData {
+    uint64_t data_low;
+    uint64_t data_high;
+};
+
 constexpr uint64_t literal1_value = 0x1234567890ABCDEF;
 constexpr uint64_t literal2_value = 0x1122334455667788;
 constexpr uint64_t literal3_value = 0xFEDCBA0987654321;
 constexpr uint64_t literal4_value = 0xAABBCCDDEEFF0011;
+constexpr std::array<uint64_t, 4> big_array = {0xDEADBEEFDEADBEEF, 0x1111111111111111, 0x2222222222222222, 0x3333333333333333};
+constexpr BigData big_data = {0xCAFECAFECAFECAFE, 0x1111111111111111};
 
-void print_literals(uint64_t literal1, uint64_t literal2, uint64_t literal3, uint64_t literal4) {
+void print_literals(uint64_t literal1, uint64_t literal2, uint64_t literal3, uint64_t literal4, uint64_t literal5, uint64_t literal6) {
     std::cout << "Literal 1: " << std::hex << literal1 << std::endl;
     std::cout << "Literal 2: " << std::hex << literal2 << std::endl;
     std::cout << "Literal 3: " << std::hex << literal3 << std::endl;
     std::cout << "Literal 4: " << std::hex << literal4 << std::endl;
+    std::cout << "Literal 5: " << std::hex << literal5 << std::endl;
+    std::cout << "Literal 6: " << std::hex << literal6 << std::endl;
 
     BISCUIT_ASSERT(literal1 == literal1_value);
     BISCUIT_ASSERT(literal2 == literal2_value);
     BISCUIT_ASSERT(literal3 == literal3_value);
     BISCUIT_ASSERT(literal4 == literal4_value);
+    BISCUIT_ASSERT(literal5 == big_array[0]);
+    BISCUIT_ASSERT(literal6 == big_data.data_low);
 }
 
 int main() {
     Assembler as(0x5000);
 
-    Literal64 literal1(literal1_value);
-    Literal64 literal2(literal2_value);
-    Literal64 literal3(literal3_value);
-    Literal64 literal4(literal4_value);
+    Literal literal1(literal1_value);
+    Literal literal2(literal2_value);
+    Literal literal3(literal3_value);
+    Literal literal4(literal4_value);
+    Literal literal5(big_array);
+    Literal literal6(big_data);
 
     // Literal placed before the code, more than 0x1000 bytes away
     as.Place(&literal1);
@@ -37,6 +50,12 @@ int main() {
 
     // Literal placed before the code, less than 0x1000 bytes away
     as.Place(&literal2);
+
+    // Place a Literal that is an array of 4 uint64_t values
+    as.Place(&literal5);
+
+    // Place a Literal that is a custom POD type
+    as.Place(&literal6);
 
     void (*code)() = reinterpret_cast<void(*)()>(as.GetCursorPointer());
     as.ADDI(sp, sp, -8);
@@ -49,6 +68,10 @@ int main() {
     as.LD(a2, &literal3);
 
     as.LD(a3, &literal4);
+
+    as.LD(a4, &literal5);
+
+    as.LD(a5, &literal6);
 
     as.LI(t0, (uint64_t)print_literals);
     as.JALR(t0);

--- a/include/biscuit/assembler.hpp
+++ b/include/biscuit/assembler.hpp
@@ -4,6 +4,7 @@
 #include <biscuit/csr.hpp>
 #include <biscuit/isa.hpp>
 #include <biscuit/label.hpp>
+#include <biscuit/literal.hpp>
 #include <biscuit/registers.hpp>
 #include <biscuit/vector.hpp>
 #include <cstddef>
@@ -151,6 +152,13 @@ public:
      */
     void Bind(Label* label);
 
+    /**
+     * Places a literal at the current offset within the code buffer.
+     *
+     * @param literal A non-null valid literal to place.
+    */
+    void Place(Literal64* literal);
+
     // RV32I Instructions
 
     void ADD(GPR rd, GPR lhs, GPR rhs) noexcept;
@@ -269,6 +277,7 @@ public:
     void ADDIW(GPR rd, GPR rs, int32_t imm) noexcept;
     void ADDW(GPR rd, GPR lhs, GPR rhs) noexcept;
     void LD(GPR rd, int32_t imm, GPR rs) noexcept;
+    void LD(GPR rd, Literal64* literal) noexcept;
     void LWU(GPR rd, int32_t imm, GPR rs) noexcept;
     void SD(GPR rs2, int32_t imm, GPR rs1) noexcept;
 
@@ -1522,6 +1531,19 @@ private:
     // branch offsets into the branch instructions that
     // requires them.
     void ResolveLabelOffsets(Label* label);
+
+    // Places a literal at the given offset.
+    template<typename T>
+    void PlaceAtOffset(Literal<T>* literal, Literal<T>::LocationOffset offset);
+
+    // Links the given literal and returns the offset to it.
+    template<typename T>
+    ptrdiff_t LinkAndGetOffset(Literal<T>* literal);
+
+    // Resolves all literal offsets and patches any necessary
+    // offsets into the load instructions that require them.
+    template<typename T>
+    void ResolveLiteralOffsets(Literal<T>* literal);
 
     CodeBuffer m_buffer;
     ArchFeature m_features = ArchFeature::RV64;

--- a/include/biscuit/literal.hpp
+++ b/include/biscuit/literal.hpp
@@ -2,9 +2,7 @@
 
 #include <biscuit/assert.hpp>
 
-#include <array>
 #include <cstddef>
-#include <cstdint>
 #include <optional>
 #include <set>
 

--- a/include/biscuit/literal.hpp
+++ b/include/biscuit/literal.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
+#include <biscuit/assert.hpp>
+
 #include <cstddef>
 #include <cstdint>
 #include <optional>
 #include <set>
-#include <biscuit/assert.hpp>
 
 namespace biscuit {
 
@@ -161,6 +162,15 @@ private:
     std::set<LocationOffset> m_offsets;
     Location m_location;
     const T m_value;
+
+    // Literals are provided as a way to avoid long instruction sequences for loading
+    // immediates to registers. As such, the Literal type is not useful for
+    // types <= uint32_t, as those can be loaded directly with at most a couple instructions.
+    // (e.g. via the LI() function in the assembler)
+    static_assert(sizeof(T) >= 8, "Literal type must be at least 64 bits wide.");
+
+    // For the assembler to be able to emit the literal value, it must be trivially copyable.
+    static_assert(std::is_trivially_copyable_v<T>, "Literal type must be trivially copyable.");
 };
 
 using Literal64 = Literal<uint64_t>;

--- a/include/biscuit/literal.hpp
+++ b/include/biscuit/literal.hpp
@@ -5,6 +5,7 @@
 #include <cstddef>
 #include <optional>
 #include <set>
+#include <type_traits>
 
 namespace biscuit {
 

--- a/include/biscuit/literal.hpp
+++ b/include/biscuit/literal.hpp
@@ -1,0 +1,168 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <set>
+#include <biscuit/assert.hpp>
+
+namespace biscuit {
+
+/**
+ * A Literal is a representation of a constant value that can be loaded into a register.
+ * This is useful for avoiding multiple instructions for loading big constants.
+ *
+ * Literals, like Labels, don't need to be placed immediately. They can be created
+ * and used with loads that require a Literal, and placed in the buffer at a later point.
+ *
+ * @note Any literal that is created, is used with a load instruction,
+ *       but is *not* placed to a location (via Place() in the assembler)
+ *       will result in an assertion being invoked when the literal instance's
+ *       destructor is executed.
+ *
+ * @note A literal may only be placed to one location. Any attempt to place
+ *       a literal that is already placed will result in an assertion being
+ *       invoked.
+ *
+ * @par
+ * An example of placing a literal:
+ * @code{.cpp}
+ * Assembler as{...};
+ * Literal64 literal(0x1234567890ABCDEF);
+ *
+ * as.LD(x2, &literal);     // Load the literal (emits a AUIPC+LD sequence)
+ * as.JR(x2);               // Execution continues elsewhere
+ * as.Place(&literal);      // Place the literal at this location in the buffer
+ * @endcode
+*/
+template<class T>
+class Literal {
+public:
+    using Location = std::optional<ptrdiff_t>;
+    using LocationOffset = Location::value_type;
+
+    /**
+     * This constructor results in a literal being constructed that is not
+     * placed at a particular location yet.
+     *
+     * @param value The value that this literal represents.
+     */
+    explicit Literal(T value) : m_value{value} {}
+
+    /// Destructor
+    ~Literal() noexcept {
+        // It's a logic bug if something references a literal and hasn't been handled.
+        //
+        // This is usually indicative of a scenario where a literal is referenced but
+        // hasn't been placed at a location.
+        //
+        BISCUIT_ASSERT(IsResolved());
+    }
+
+    // Copying disabled for the same reasons as Labels.
+    Literal(const Literal&) = delete;
+    Literal& operator=(const Literal&) = delete;
+
+    Literal(Literal&&) noexcept = default;
+    Literal& operator=(Literal&&) noexcept = default;
+
+    /**
+     * Determines whether or not this literal instance has a location assigned to it.
+     *
+     * A literal is considered placed if it has an assigned location.
+     */
+    [[nodiscard]] bool IsPlaced() const noexcept {
+        return m_location.has_value();
+    }
+
+    /**
+     * Determines whether or not this literal is resolved.
+     *
+     * A literal is considered resolved when all referencing offsets have been handled.
+     */
+    [[nodiscard]] bool IsResolved() const noexcept {
+        return m_offsets.empty();
+    }
+
+    /**
+     * Determines whether or not this literal is unresolved.
+     *
+     * A literal is considered unresolved if it still has any unhandled referencing offsets.
+     */
+    [[nodiscard]] bool IsUnresolved() const noexcept {
+        return !IsResolved();
+    }
+
+    /**
+     * Retrieves the location for this literal.
+     *
+     * @note If the returned location is empty, then this literal has not been assigned
+     *       a location yet.
+     */
+    [[nodiscard]] Location GetLocation() const noexcept {
+        return m_location;
+    }
+
+private:
+    // A literal instance is inherently bound to the assembler it's
+    // used with, as the offsets within the literal set depend on
+    // said assemblers code buffer.
+    friend class Assembler;
+
+    /**
+     * Places a literal to the given location.
+     *
+     * @param offset The offset to place this literal at.
+     *
+     * @returns The literal value so it can be copied to memory by the assembler.
+     *
+     * @pre The literal must not have already been placed at a previous location.
+     *      Attempting to place a literal multiple times is typically, in almost all scenarios,
+     *      the source of bugs.
+     *      Attempting to place an already placed literal will result in an assertion
+     *      being triggered.
+     */
+    [[nodiscard]] const T& Place(LocationOffset offset) noexcept {
+        BISCUIT_ASSERT(!IsPlaced());
+        m_location = offset;
+        return m_value;
+    }
+
+    /**
+     * Marks the given address as dependent on this literal.
+     *
+     * This is used in scenarios where a literal exists, but has not yet been
+     * placed at a location yet. It's important to track these addresses,
+     * as we'll need to patch the dependent load instructions with the
+     * proper offset once the literal is finally placed by the assembler.
+     *
+     * During literal placement, the offset will be calculated and inserted
+     * into dependent instructions.
+     */
+    void AddOffset(LocationOffset offset) {
+        // If a literal is already placed at a location, then offset tracking
+        // isn't necessary. Tripping this assert means we have a bug somewhere.
+        BISCUIT_ASSERT(!IsPlaced());
+        BISCUIT_ASSERT(IsNewOffset(offset));
+
+        m_offsets.insert(offset);
+    }
+
+    // Clears all the underlying offsets for this literal.
+    void ClearOffsets() noexcept {
+        m_offsets.clear();
+    }
+
+    // Determines whether or not this address has already been added before.
+    [[nodiscard]] bool IsNewOffset(LocationOffset offset) const noexcept {
+        return m_offsets.find(offset) == m_offsets.cend();
+    }
+
+    std::set<LocationOffset> m_offsets;
+    Location m_location;
+    const T m_value;
+};
+
+using Literal64 = Literal<uint64_t>;
+
+} // namespace biscuit

--- a/include/biscuit/literal.hpp
+++ b/include/biscuit/literal.hpp
@@ -2,6 +2,7 @@
 
 #include <biscuit/assert.hpp>
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <optional>
@@ -29,7 +30,7 @@ namespace biscuit {
  * An example of placing a literal:
  * @code{.cpp}
  * Assembler as{...};
- * Literal64 literal(0x1234567890ABCDEF);
+ * Literal literal(0x1234567890ABCDEF);
  *
  * as.LD(x2, &literal);     // Load the literal (emits a AUIPC+LD sequence)
  * as.JR(x2);               // Execution continues elsewhere
@@ -172,7 +173,5 @@ private:
     // For the assembler to be able to emit the literal value, it must be trivially copyable.
     static_assert(std::is_trivially_copyable_v<T>, "Literal type must be trivially copyable.");
 };
-
-using Literal64 = Literal<uint64_t>;
 
 } // namespace biscuit

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -29,6 +29,10 @@ void Assembler::Bind(Label* label) {
     BindToOffset(label, m_buffer.GetCursorOffset());
 }
 
+void Assembler::Place(Literal64* literal) {
+    PlaceAtOffset(literal, m_buffer.GetCursorOffset());
+}
+
 void Assembler::ADD(GPR rd, GPR lhs, GPR rhs) noexcept {
     EmitRType(m_buffer, 0b0000000, rhs, lhs, 0b000, rd, 0b0110011);
 }
@@ -529,6 +533,15 @@ void Assembler::LD(GPR rd, int32_t imm, GPR rs) noexcept {
     BISCUIT_ASSERT(IsRV32OrRV64(m_features));
     BISCUIT_ASSERT(IsValidSigned12BitImm(imm));
     EmitIType(m_buffer, static_cast<uint32_t>(imm), rs, 0b011, rd, 0b0000011);
+}
+
+void Assembler::LD(GPR rd, Literal64* literal) noexcept {
+    BISCUIT_ASSERT(IsRV64(m_features));
+    const auto offset = LinkAndGetOffset(literal);
+    const auto hi20 = static_cast<int32_t>((static_cast<uint32_t>(offset) + 0x800) >> 12 & 0xFFFFF);
+    const auto lo12 = static_cast<int32_t>(offset << 20) >> 20;
+    AUIPC(rd, hi20);
+    LD(rd, lo12, rd);
 }
 
 void Assembler::LWU(GPR rd, int32_t imm, GPR rs) noexcept {
@@ -1505,6 +1518,85 @@ void Assembler::ResolveLabelOffsets(Label* label) {
         }
 
         std::memcpy(ptr, &instruction, inst_size);
+    }
+}
+
+template <typename T>
+void Assembler::PlaceAtOffset(Literal<T>* literal, Literal<T>::LocationOffset offset) {
+    BISCUIT_ASSERT(literal != nullptr);
+    BISCUIT_ASSERT(offset >= 0 && offset <= m_buffer.GetCursorOffset());
+
+    const T& value = literal->Place(offset);
+    ResolveLiteralOffsets(literal);
+    literal->ClearOffsets();
+
+    m_buffer.Emit(value);
+}
+
+template <typename T>
+ptrdiff_t Assembler::LinkAndGetOffset(Literal<T>* literal) {
+    BISCUIT_ASSERT(literal != nullptr);
+
+    // If we have a placed literal, then it's straightforward to calculate
+    // the offsets.
+    if (literal->IsPlaced()) {
+        const auto cursor_address = m_buffer.GetCursorAddress();
+        const auto literal_offset = m_buffer.GetOffsetAddress(*literal->GetLocation());
+        return static_cast<ptrdiff_t>(literal_offset - cursor_address);
+    }
+
+    // If we don't have a placed literal, we return an offset of zero.
+    // While the emitter will emit a bogus load instruction initially,
+    // the offset will be patched over once the literal has been properly
+    // placed at a location.
+    literal->AddOffset(m_buffer.GetCursorOffset());
+    return 0;
+}
+
+template <typename T>
+void Assembler::ResolveLiteralOffsets(Literal<T>* literal) {
+    const auto is_auipc_type = [](uint32_t instruction) {
+        return (instruction & 0x7F) == 0b0010111;
+    };
+
+    const auto is_gpr_load_type = [](uint32_t instruction) {
+        return (instruction & 0x7F) == 0b0000011;
+    };
+
+    const auto literal_location = *literal->GetLocation();
+
+    for (const auto offset : literal->m_offsets) {
+        const auto address = m_buffer.GetOffsetAddress(offset);
+        auto* const ptr = reinterpret_cast<uint8_t*>(address);
+
+        uint32_t instructions[2] = {0, 0};
+        std::memcpy(&instructions[0], ptr, sizeof(uint32_t));
+        std::memcpy(&instructions[1], ptr + sizeof(uint32_t), sizeof(uint32_t));
+
+        // Given all load instructions we need to patch have 0 encoded as
+        // their load offset, we don't need to worry about any masking work.
+        //
+        // It's enough to verify that the immediate is going to be valid
+        // and then OR it into the instruction.
+
+        const auto encoded_offset = literal_location - offset;
+
+        BISCUIT_ASSERT(is_auipc_type(instructions[0]));
+
+        // Make sure the distance is within the bounds of a 32-bit signed integer.
+        BISCUIT_ASSERT((static_cast<int64_t>(encoded_offset << 32) >> 32) == encoded_offset);
+
+        if (is_gpr_load_type(instructions[1])) {
+            const auto high20 = static_cast<uint32_t>(encoded_offset & 0xFFFFF000);
+            const auto low12 = static_cast<uint32_t>(encoded_offset & 0xFFF);
+            instructions[0] |= high20;
+            instructions[1] |= low12 << 20;
+        } else {
+            BISCUIT_ASSERT(false);
+        }
+
+        std::memcpy(ptr, &instructions[0], sizeof(uint32_t));
+        std::memcpy(ptr + sizeof(uint32_t), &instructions[1], sizeof(uint32_t));
     }
 }
 

--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -1,6 +1,7 @@
 #include <biscuit/assert.hpp>
 #include <biscuit/assembler.hpp>
 
+#include <array>
 #include <bit>
 #include <cstring>
 #include <utility>
@@ -1569,7 +1570,7 @@ void Assembler::ResolveLiteralOffsets(Literal<T>* literal) {
         const auto address = m_buffer.GetOffsetAddress(offset);
         auto* const ptr = reinterpret_cast<uint8_t*>(address);
 
-        uint32_t instructions[2] = {0, 0};
+        std::array<uint32_t, 2> instructions{};
         std::memcpy(&instructions[0], ptr, sizeof(uint32_t));
         std::memcpy(&instructions[1], ptr + sizeof(uint32_t), sizeof(uint32_t));
 


### PR DESCRIPTION
As mentioned in #7, these can be nice to have to avoid the many instructions it takes to load some immediates.

I implemented them in a very similar fashion to Label, and they should be extensible to some larger type in the future for vector register loads.

Doesn't handle the mentioned case of pc relative stores. Let me know what you think.