### PR TITLE
Allow directly setting the cursor pointer

### DIFF
--- a/include/biscuit/assembler.hpp
+++ b/include/biscuit/assembler.hpp
@@ -135,6 +135,11 @@ public:
         return m_buffer.GetCursorPointer();
     }
 
+    /// Sets the cursor pointer for the underlying code buffer.
+    void SetCursorPointer(uint8_t* ptr) noexcept {
+        m_buffer.SetCursorPointer(ptr);
+    }
+
     /// Retrieves the pointer to an arbitrary location within the underlying code buffer.
     [[nodiscard]] uint8_t* GetBufferPointer(ptrdiff_t offset) noexcept {
         return m_buffer.GetOffsetPointer(offset);

--- a/include/biscuit/code_buffer.hpp
+++ b/include/biscuit/code_buffer.hpp
@@ -81,6 +81,12 @@ public:
         return GetOffsetPointer(GetCursorOffset());
     }
 
+    /// Sets the cursor pointer
+    void SetCursorPointer(uint8_t* ptr) noexcept {
+        BISCUIT_ASSERT(ptr >= m_buffer && ptr < m_buffer + m_capacity);
+        m_cursor = ptr;
+    }
+
     /// Retrieves the address of an arbitrary offset within the buffer.
     [[nodiscard]] uintptr_t GetOffsetAddress(ptrdiff_t offset) const noexcept {
         return reinterpret_cast<uintptr_t>(GetOffsetPointer(offset));


### PR DESCRIPTION
I find the Rewind/Advance stuff a bit uncomfortable to use compared to using Xbyak's setCurr/getCurr, dealing with offsets ends up making the code look clunkier IMO.

For example, if I want a pointer to a specific location in the buffer and I want to also be able to rewind to it, either I store an offset and need to add the base buffer pointer every time I wanna do a read from that place, or I store the cursor pointer but I need to subtract the base when I need to rewind/advance there.

Being able to set a pointer like this makes it a whole lot easier for me. The cursor pointer can both read/written and rewind/advanced to.