### PR TITLE
Remove address assert from amocas

### DIFF
--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -596,7 +596,6 @@ void Assembler::WRS_STO() noexcept {
 void Assembler::AMOCAS_D(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
     if (IsRV32(m_features)) {
         BISCUIT_ASSERT((rd.Index() % 2) == 0);
-        BISCUIT_ASSERT((rs1.Index() % 2) == 0);
         BISCUIT_ASSERT((rs2.Index() % 2) == 0);
     }
     EmitAtomic(m_buffer, 0b00101, ordering, rs2, rs1, 0b011, rd, 0b0101111);
@@ -606,7 +605,6 @@ void Assembler::AMOCAS_Q(Ordering ordering, GPR rd, GPR rs2, GPR rs1) noexcept {
 
     // Both rd and rs2 indicate a register pair, so they need to be even-numbered.
     BISCUIT_ASSERT((rd.Index() % 2) == 0);
-    BISCUIT_ASSERT((rs1.Index() % 2) == 0);
     BISCUIT_ASSERT((rs2.Index() % 2) == 0);
     EmitAtomic(m_buffer, 0b00101, ordering, rs2, rs1, 0b100, rd, 0b0101111);
 }


### PR DESCRIPTION
The address doesn't need to be aligned to a register pair