### PR TITLE
cpuinfo: Add new bits

### DIFF
--- a/include/biscuit/cpuinfo.hpp
+++ b/include/biscuit/cpuinfo.hpp
@@ -66,7 +66,16 @@ enum class RISCVExtension : uint64_t {
     Zcd,
     Zcf,
     Zcmop,
-    Zawrs
+    Zawrs,
+    Supm,
+    Zicntr,
+    Zihpm,
+    Zfbfmin,
+    Zvfbfmin,
+    Zvfbfwma,
+    Zicbom,
+    Zaamo,
+    Zalrsc
 };
 
 template <CSR csr>

--- a/src/cpuinfo.cpp
+++ b/src/cpuinfo.cpp
@@ -220,6 +220,42 @@
 #define RISCV_HWPROBE_EXT_ZAWRS         (1ULL << 48)
 #endif
 
+#ifndef RISCV_HWPROBE_EXT_SUPM
+#define RISCV_HWPROBE_EXT_SUPM          (1ULL << 49)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZICNTR
+#define RISCV_HWPROBE_EXT_ZICNTR        (1ULL << 50)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZIHPM
+#define RISCV_HWPROBE_EXT_ZIHPM         (1ULL << 51)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZFBFMIN
+#define RISCV_HWPROBE_EXT_ZFBFMIN       (1ULL << 52)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZVFBFMIN
+#define RISCV_HWPROBE_EXT_ZVFBFMIN      (1ULL << 53)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZVFBFWMA
+#define RISCV_HWPROBE_EXT_ZVFBFWMA      (1ULL << 54)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZICBOM
+#define RISCV_HWPROBE_EXT_ZICBOM        (1ULL << 55)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZAAMO
+#define RISCV_HWPROBE_EXT_ZAAMO         (1ULL << 56)
+#endif
+
+#ifndef RISCV_HWPROBE_EXT_ZALRSC
+#define RISCV_HWPROBE_EXT_ZALRSC        (1ULL << 57)
+#endif
+
 #ifndef COMPAT_HWCAP_ISA_I
 #define COMPAT_HWCAP_ISA_I  (1U << ('I' - 'A'))
 #endif
@@ -410,6 +446,24 @@ bool CPUInfo::Has(RISCVExtension extension) const {
             return (features0 & RISCV_HWPROBE_EXT_ZCMOP) != 0;
         case RISCVExtension::Zawrs:
             return (features0 & RISCV_HWPROBE_EXT_ZAWRS) != 0;
+        case RISCVExtension::Supm:
+            return (features0 & RISCV_HWPROBE_EXT_SUPM) != 0;
+        case RISCVExtension::Zicntr:
+            return (features0 & RISCV_HWPROBE_EXT_ZICNTR) != 0;
+        case RISCVExtension::Zihpm:
+            return (features0 & RISCV_HWPROBE_EXT_ZIHPM) != 0;
+        case RISCVExtension::Zfbfmin:
+            return (features0 & RISCV_HWPROBE_EXT_ZFBFMIN) != 0;
+        case RISCVExtension::Zvfbfmin:
+            return (features0 & RISCV_HWPROBE_EXT_ZVFBFMIN) != 0;
+        case RISCVExtension::Zvfbfwma:
+            return (features0 & RISCV_HWPROBE_EXT_ZVFBFWMA) != 0;
+        case RISCVExtension::Zicbom:
+            return (features0 & RISCV_HWPROBE_EXT_ZICBOM) != 0;
+        case RISCVExtension::Zaamo:
+            return (features0 & RISCV_HWPROBE_EXT_ZAAMO) != 0;
+        case RISCVExtension::Zalrsc:
+            return (features0 & RISCV_HWPROBE_EXT_ZALRSC) != 0;
     }
 
     return false;


### PR DESCRIPTION
One annoying issue is that older kernels don't have these newer bits. So a value of 0 doesn't mean "CPU doesn't have this extension", it means "doesn't have this extension or kernel too old".

I guess the signal handler stuff would be the better solution to this unfortunately, but then it wouldn't detect extensions that don't define new instructions. It would also not be able to detect instructions that are nops in CPUs that don't have them, like the ones in Zihintntl

What do you think, should CPUInfo move to signal handlers? Then we could get rid of the old auxv stuff too. And maybe keep the syscall for the otherwise undetectable extensions?