### PR TITLE
assembler: Add newer mnemonics for VFREDSUM

### DIFF
--- a/include/biscuit/assembler.hpp
+++ b/include/biscuit/assembler.hpp
@@ -1236,6 +1236,7 @@ public:
     void VFREDMIN(Vec vd, Vec vs2, Vec vs1, VecMask mask = VecMask::No) noexcept;
 
     void VFREDSUM(Vec vd, Vec vs2, Vec vs1, VecMask mask = VecMask::No) noexcept;
+    void VFREDUSUM(Vec vd, Vec vs2, Vec vs1, VecMask mask = VecMask::No) noexcept;
     void VFREDOSUM(Vec vd, Vec vs2, Vec vs1, VecMask mask = VecMask::No) noexcept;
 
     void VFMACC(Vec vd, Vec vs1, Vec vs2, VecMask mask = VecMask::No) noexcept;
@@ -1320,6 +1321,7 @@ public:
     void VFWNMSAC(Vec vd, FPR rs1, Vec vs2, VecMask mask = VecMask::No) noexcept;
 
     void VFWREDSUM(Vec vd, Vec vs2, Vec vs1, VecMask mask = VecMask::No) noexcept;
+    void VFWREDUSUM(Vec vd, Vec vs2, Vec vs1, VecMask mask = VecMask::No) noexcept;
     void VFWREDOSUM(Vec vd, Vec vs2, Vec vs1, VecMask mask = VecMask::No) noexcept;
 
     void VFWMSAC(Vec vd, Vec vs1, Vec vs2, VecMask mask = VecMask::No) noexcept;

--- a/src/assembler_vector.cpp
+++ b/src/assembler_vector.cpp
@@ -1235,6 +1235,10 @@ void Assembler::VFREDSUM(Vec vd, Vec vs2, Vec vs1, VecMask mask) noexcept {
     EmitVectorOPFVV(m_buffer, 0b000001, mask, vs2, vs1, vd);
 }
 
+void Assembler::VFREDUSUM(Vec vd, Vec vs2, Vec vs1, VecMask mask) noexcept {
+    VFREDSUM(vd, vs2, vs1, mask);
+}
+
 void Assembler::VFREDOSUM(Vec vd, Vec vs2, Vec vs1, VecMask mask) noexcept {
     EmitVectorOPFVV(m_buffer, 0b000011, mask, vs2, vs1, vd);
 }
@@ -1457,6 +1461,10 @@ void Assembler::VFWNMSAC(Vec vd, FPR rs1, Vec vs2, VecMask mask) noexcept {
 
 void Assembler::VFWREDSUM(Vec vd, Vec vs2, Vec vs1, VecMask mask) noexcept {
     EmitVectorOPFVV(m_buffer, 0b110001, mask, vs2, vs1, vd);
+}
+
+void Assembler::VFWREDUSUM(Vec vd, Vec vs2, Vec vs1, VecMask mask) noexcept {
+    VFWREDSUM(vd, vs2, vs1, mask);
 }
 
 void Assembler::VFWREDOSUM(Vec vd, Vec vs2, Vec vs1, VecMask mask) noexcept {


### PR DESCRIPTION
RVV 1.0:
> Older assembler mnemonic vfredsum is retained as alias for vfredusum
> Older assembler mnemonic vfwredsum is retained as alias for vfwredusum