### PR TITLE
Fixup CJ immediate

### DIFF
--- a/examples/literal/literal.cpp
+++ b/examples/literal/literal.cpp
@@ -1,6 +1,7 @@
 #include <biscuit/assert.hpp>
 #include <biscuit/assembler.hpp>
 
+#include <array>
 #include <iostream>
 
 using namespace biscuit;

--- a/src/assembler_util.hpp
+++ b/src/assembler_util.hpp
@@ -97,7 +97,7 @@ namespace biscuit {
            ((imm & 0x400) >> 2) |
            ((imm & 0x040) << 1) |
            ((imm & 0x080) >> 1) |
-           ((imm & 0x00E) << 4) |
+           ((imm & 0x00E) << 2) |
            ((imm & 0x020) >> 3);
     // clang-format on
 }

--- a/tests/src/assembler_branch_tests.cpp
+++ b/tests/src/assembler_branch_tests.cpp
@@ -87,7 +87,7 @@ TEST_CASE("Branch with Instructions Between", "[branch]") {
         as.ADD(x1, x2, x3);
         as.SUB(x2, x4, x3);
         as.C_J(&label);
-        REQUIRE((data[2] & 0xFFFF) == 0xBFC5);
+        REQUIRE((data[2] & 0xFFFF) == 0xBFE5);
     }
 
     as.RewindBuffer();
@@ -100,6 +100,6 @@ TEST_CASE("Branch with Instructions Between", "[branch]") {
         as.ADD(x1, x2, x3);
         as.SUB(x2, x4, x3);
         as.Bind(&label);
-        REQUIRE((data[0] & 0xFFFF) == 0xA0A1);
+        REQUIRE((data[0] & 0xFFFF) == 0xA029);
     }
 }

--- a/tests/src/assembler_rvc_tests.cpp
+++ b/tests/src/assembler_rvc_tests.cpp
@@ -237,6 +237,32 @@ TEST_CASE("C.FSWSP", "[rvc]") {
     REQUIRE(value == 0xEC3E);
 }
 
+TEST_CASE("C.JAL", "[rvc]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler32(value);
+
+    as.C_JAL(1028);
+    REQUIRE(value == 0x2111);
+
+    as.RewindBuffer();
+
+    as.C_JAL(-1028);
+    REQUIRE(value == 0x3EF5);
+}
+
+TEST_CASE("C.J", "[rvc]") {
+    uint32_t value = 0;
+    auto as = MakeAssembler32(value);
+
+    as.C_J(1028);
+    REQUIRE(value == 0xA111);
+
+    as.RewindBuffer();
+
+    as.C_J(-1028);
+    REQUIRE(value == 0xBEF5);
+}
+
 TEST_CASE("C.JALR", "[rvc]") {
     uint32_t value = 0;
     auto as = MakeAssembler32(value);


### PR DESCRIPTION
C.J and C.JAL encoding would take bits 1-3 of the immediate (`imm & 0x00E`) and shift them left by 4, placing them at bits 5-7 in the instruction.

However, bits 1-3 should be placed at bits 3-5:
<img width="870" height="129" alt="image" src="https://github.com/user-attachments/assets/a17d9a44-18d4-4d3b-9dc2-689ab5edb8d6" />

As a result the branch tests were wrong too.
0xBFC5 is c.j -16, instead of the expected c.j -8
0xA0A1 is c.j 72, instead of the expected c.j 10

---

Also added an include in literal.cpp cus it was causing compilation errors when missing