### PR TITLE
Change C.LUI API

### DIFF
--- a/src/assembler_compressed.cpp
+++ b/src/assembler_compressed.cpp
@@ -438,9 +438,9 @@ void Assembler::C_LQSP(GPR rd, uint32_t imm) noexcept {
 void Assembler::C_LUI(GPR rd, uint32_t imm) noexcept {
     BISCUIT_ASSERT(imm != 0);
     BISCUIT_ASSERT(rd != x0 && rd != x2);
+    BISCUIT_ASSERT(imm <= 0x3F);
 
-    const auto new_imm = (imm & 0x3F000) >> 12;
-    EmitCompressedImmediate(m_buffer, 0b011, new_imm, rd, 0b01);
+    EmitCompressedImmediate(m_buffer, 0b011, imm, rd, 0b01);
 }
 
 void Assembler::C_LW(GPR rd, uint32_t imm, GPR rs) noexcept {

--- a/tests/src/assembler_rvc_tests.cpp
+++ b/tests/src/assembler_rvc_tests.cpp
@@ -337,12 +337,12 @@ TEST_CASE("C.LUI", "[rvc]") {
     uint32_t value = 0;
     auto as = MakeAssembler32(value);
 
-    as.C_LUI(x15, 0x3F000);
+    as.C_LUI(x15, 0x3F);
     REQUIRE(value == 0x77FD);
 
     as.RewindBuffer();
 
-    as.C_LUI(x15, 0x0F000);
+    as.C_LUI(x15, 0x0F);
     REQUIRE(value == 0x67BD);
 }
 


### PR DESCRIPTION
LUI and AUIPC take the unshifted immediate as an argument. C.LUI takes the shifted-by-12 immediate. I think that C.LUI should be changed to take the unshifted immediate so the API is more consistent.

This would break backwards compatibility with uses of C.LUI. But any previous usage of C.LUI should hit the new assert, so at least it won't emit a bad opcode silently.