### PR TITLE
Fix condition for auto-compressing ADD

### DIFF
--- a/src/assembler.cpp
+++ b/src/assembler.cpp
@@ -32,7 +32,7 @@ void Assembler::Bind(Label* label) {
 
 void Assembler::ADD(GPR rd, GPR lhs, GPR rhs) noexcept {
     if (IsOptimizationEnabled(Optimization::AutoCompress)) {
-        if (IsValid3BitCompressedReg(rd) && IsValid3BitCompressedReg(lhs) && IsValid3BitCompressedReg(rhs)) {
+        if (rd != x0 && lhs != x0 && rhs != x0) {
             if (rd == lhs) {
                 C_ADD(rd, rhs);
                 return;


### PR DESCRIPTION
Unlike C.AND/OR/XOR/SUB/ADDW/SUBW, C.ADD can work with all registers.